### PR TITLE
Fix header matching

### DIFF
--- a/cloudify_azure/resources/base.py
+++ b/cloudify_azure/resources/base.py
@@ -91,10 +91,9 @@ class Resource(object):
         res = self.client.request(
             method='get',
             url=url)
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # Check the response
         # HTTP 202 (ACCEPTED) - The operation has started but is asynchronous
         if res.status_code == httplib.ACCEPTED:
@@ -146,10 +145,9 @@ class Resource(object):
             method='put',
             url='{0}/{1}'.format(self.endpoint, name),
             json=params)
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # Check the response
         # HTTP 201 (CREATED) - The operation succeeded
         if res.status_code == httplib.CREATED:
@@ -252,10 +250,9 @@ class Resource(object):
             method='put',
             url='{0}/{1}'.format(self.endpoint, name),
             json=params)
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # Check the response
         # HTTP 202 (ACCEPTED) - The operation has started but is asynchronous
         if res.status_code == httplib.ACCEPTED:
@@ -337,10 +334,9 @@ class Resource(object):
         res = self.client.request(
             method='delete',
             url='{0}/{1}'.format(self.endpoint, name))
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # HTTP 200 (OK) - The operation is successful and complete
         if res.status_code == httplib.OK:
             return
@@ -406,10 +402,9 @@ class Resource(object):
         res = self.client.request(
             method='get',
             url=url)
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # Check the response
         # HTTP 202 (ACCEPTED) - An asynchronous operation has started
         if res.status_code == httplib.ACCEPTED:
@@ -445,10 +440,9 @@ class Resource(object):
             op_info.get('azure-asyncoperation')
         res = self.client.request(method='get',
                                   url=op_url)
-        # Convert headers from CaseInsensitiveDict to Dict
-        headers = dict(res.headers)
         self.log.debug('headers: {0}'.format(
-            utils.secure_logging_content(headers)))
+            utils.secure_logging_content(dict(res.headers))))
+        headers = self.lowercase_headers(res.headers)
         # HTTP 200 (OK) - Operation is successful and complete
         if res.status_code == httplib.OK:
             if self.validate_res_json(res) == 'InProgress':
@@ -540,3 +534,8 @@ class Resource(object):
             return None
         return yaml.safe_load(
             json.dumps(us_data, ensure_ascii=True).encode('utf8'))
+
+    @staticmethod
+    def lowercase_headers(headers):
+        # Convert headers from CaseInsensitiveDict to Dict
+        return dict(headers.lower_items())

--- a/cloudify_azure/tests/common.py
+++ b/cloudify_azure/tests/common.py
@@ -99,9 +99,9 @@ def mock_endpoints(mock, params, res_type,
         'PUT',
         endpoint,
         headers={
-            'location': params['mock_retry_url'],
+            'Location': params['mock_retry_url'],
             'x-ms-request-id': '123412341234',
-            'retry-after': '1'
+            'Retry-After': '1'
         },
         status_code=httplib.ACCEPTED
     )

--- a/cloudify_azure/tests/resources/test_base.py
+++ b/cloudify_azure/tests/resources/test_base.py
@@ -129,7 +129,7 @@ class ResourcesBaseTestCase(unittest.TestCase):
             'virtualMachines')
         headers = {
             'x-ms-request-id': 'test-id-string',
-            'retry-after': '1'
+            'Retry-After': '1'
         }
         self.mock_endpoints(mock, endpoint, res_name,
                             json={'response': 'ok'},
@@ -159,8 +159,8 @@ class ResourcesBaseTestCase(unittest.TestCase):
             'providers/Microsoft.Compute',
             'virtualMachines')
         headers = {
-            'location': 'https://test.com/test',
-            'retry-after': '1'
+            'Location': 'https://test.com/test',
+            'Retry-After': '1'
         }
         self.mock_endpoints(mock, endpoint, res_name,
                             json={'response': 'ok'},
@@ -176,7 +176,7 @@ class ResourcesBaseTestCase(unittest.TestCase):
         res.get(name=res_name)
         self.assertEqual(
             self.ctx.instance.runtime_properties.get('async_op'),
-            headers)
+            dict((k.lower(), v) for k, v in headers.items()))
 
     @requests_mock.Mocker()
     def test_accepted(self, mock):
@@ -188,9 +188,9 @@ class ResourcesBaseTestCase(unittest.TestCase):
             'providers/Microsoft.Compute',
             'virtualMachines')
         headers = {
-            'location': 'https://test.com/test',
+            'Location': 'https://test.com/test',
             'x-ms-request-id': 'test-id-string',
-            'retry-after': '1'
+            'Retry-After': '1'
         }
         self.mock_endpoints(mock, endpoint, res_name,
                             json={'response': 'ok'},
@@ -206,4 +206,4 @@ class ResourcesBaseTestCase(unittest.TestCase):
         res.get(name=res_name)
         self.assertEqual(
             self.ctx.instance.runtime_properties.get('async_op'),
-            headers)
+            dict((k.lower(), v) for k, v in headers.items()))

--- a/cloudify_azure/tests/resources/test_resourcegroup.py
+++ b/cloudify_azure/tests/resources/test_resourcegroup.py
@@ -78,9 +78,9 @@ class TestResourceGroup(unittest.TestCase):
                     self.mock_res_name,
                     constants.API_VER_RESOURCES)),
             headers={
-                'location': self.mock_retry_url,
+                'Location': self.mock_retry_url,
                 'x-ms-request-id': '123412341234',
-                'retry-after': '1'
+                'Retry-After': '1'
             },
             status_code=httplib.ACCEPTED
         )

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     -rdev-requirements.txt
     -rtest-requirements.txt
 commands =
-    nosetests -s -v --with-cov --cov-report term-missing --cov cloudify_azure cloudify_azure/tests
+    nosetests -s -v --with-cov --cov-report term-missing --cov cloudify_azure {posargs:cloudify_azure/tests}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Make sure Azure response headers are properly converted to lowercase keys.

Unfortunately it's not possible to easily write a test for this issue because requests-mock uses urllib3's HTTPResponse when building mock responses, and that implicitly converts the headers we supply in tests to lowercase. The alternative is passing a raw response to requests-mock. For now I've just updated the tests to be supplying more accurate header data even if it's a bit pointless.

Fixes #77, fixes #61.
